### PR TITLE
fix native Polish label ('Polski')

### DIFF
--- a/themes/crisp/translations/de.json
+++ b/themes/crisp/translations/de.json
@@ -41,7 +41,7 @@
     "base.language.native.es_MX": "Español mexicano",
     "base.language.native.fr": "Français",
     "base.language.native.nl": "Nederlands",
-    "base.language.native.pl": "Polskie",
+    "base.language.native.pl": "Polski",
     "base.language.native.pt_BR": "Português brasileiro",
     "base.language.native.ru": "Русский",
     "base.language.nl": "Niederländisch",

--- a/themes/crisp/translations/ru.json
+++ b/themes/crisp/translations/ru.json
@@ -17,7 +17,7 @@
     "base.language.native.es_MX": "Español mexicano",
     "base.language.native.fr": "Français",
     "base.language.native.nl": "Nederlands",
-    "base.language.native.pl": "Polskie",
+    "base.language.native.pl": "Polski",
     "base.language.native.pt_BR": "Português brasileiro",
     "base.language.native.ru": "Русский",
     "base.language.nl": "Датский",


### PR DESCRIPTION
I don't speak Polish, but Google Translate and [Wikipedia](https://en.wikipedia.org/wiki/List_of_language_names#P) say it's "Polski", not "Polskie".