### PR TITLE
Fix CRISP-179, ErrorException: Warning: parse_ini_file

### DIFF
--- a/themes/crisp/includes/_prod/frontpage.php
+++ b/themes/crisp/includes/_prod/frontpage.php
@@ -26,7 +26,6 @@ if(!defined('CRISP_COMPONENT')){
 }
 
 $Services = [];
-$EnvFile = parse_ini_file(__DIR__ . '/../../../.env');
 
 if (!isset($_GET['search'])) {
     foreach (Config::get('frontpage_services') as $ID) {


### PR DESCRIPTION
Fixes https://sentry.tosdr.org/share/issue/bfd98145853d4157b87123238e30f82f/ and CRISP-179

Signed-off-by: Justin René Back <justin.back@tosdr.org>